### PR TITLE
chore/a11y : Title change

### DIFF
--- a/src/defines/localisation/commands/introduction.json
+++ b/src/defines/localisation/commands/introduction.json
@@ -9,7 +9,7 @@
     "ABOUT": "> **Diga um pouco sobre você:** (Exemplo: Me chamo Gustavo...)",
     "GIT": "> **Qual é seu Git?** (Exemplo: https://github.com/DanielHe4rt)",
     "LINKEDIN": "> **Qual é seu Linkedin?** (Exemplo: https://br.linkedin.com/in/danielheart)",
-    "UF": ">  **Qual é o seu estado?**\n",
+    "UF": ">  **Qual é o seu estado?** (Digite o número designado para a linguagem que queira receber um cargo no servidor)\n",
     "LANGUAGES": "> **Linguagens?** (Digite o número designado para a linguagem que queira receber um cargo no servidor)\n\n",
     "ENGLISH": "> **Nível de Inglês?**",
     "DELAS": "**Você se identifica como parte do projeto @💗 He4rt Delas(ela/dela)?**\n\n ⚠️ (Espaço restrito para mulheres e pessoas não-binárias, caso você **digite 1** sem se identificar ou desrespeite este espaço = banimento)\n\n"


### PR DESCRIPTION
The non-insertion of the atributive description of parameters makes many people err when selecting the city in which they reside.

> Only the title was changed so that a callsign is sent together with the city selector.