### PR TITLE
fix: only react to default messages in learning diary

### DIFF
--- a/src/events/discord/channel.ts
+++ b/src/events/discord/channel.ts
@@ -8,7 +8,7 @@ import {
 } from '@/defines/ids.json'
 import { HE4RT_EMOJI_ID } from '@/defines/ids.json'
 import { isAdministrator, isImageHTTPUrl, isValidProxyContent, js } from '@/utils'
-import { ChannelType, GuildMember, Message } from 'discord.js'
+import { ChannelType, GuildMember, Message, MessageType } from 'discord.js'
 import { He4rtClient, MessagePOST } from '@/types'
 
 export const MessageListener = (client: He4rtClient, message: Message) => {
@@ -106,7 +106,7 @@ export const reactMessagesInSuggestionChannel = async (message: Message) => {
 }
 
 export const reactMessagesInLearningDiaryChannel = async (message: Message) => {
-  if (LEARNING_DIARY_CHANNEL.id === message.channel.id) {
+  if (LEARNING_DIARY_CHANNEL.id === message.channel.id && message.type === MessageType.Default) {
     await message.react(HE4RT_EMOJI_ID).catch(() => {})
   }
 }


### PR DESCRIPTION
Currently, the bot is open to giving its heart for every message from the learning diary, albeit improper message types. Thread creation is a common one that should not receive its grace.

This PR addresses it by selecting the love-receiving messages only when from the default message type.