### PR TITLE
feat: suggest introduction cmd and sticky call-to-action

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,7 +4,7 @@ import { useAnnounce } from './announce'
 import { useBan } from './ban'
 import { useColor } from './color'
 import { useDaily } from './daily'
-import { useIntroduction } from './introduction'
+import { resolveIntroduceCommandButtonEvents, useIntroduction } from './introduction'
 import { useProfileGet } from './profile/profile_get'
 import { useRanking } from './ranking'
 import { useUnban } from './unban'
@@ -116,4 +116,5 @@ export const commandsListener = (client: He4rtClient, interaction: CommandIntera
 
 export const buttonListener = async (client: He4rtClient, interaction: ButtonInteraction) => {
   await resolveJudgeCommandButtonEvents(client, interaction)
+  await resolveIntroduceCommandButtonEvents(client, interaction)
 }

--- a/src/commands/introduction.ts
+++ b/src/commands/introduction.ts
@@ -1,5 +1,5 @@
-import { CommandInteraction, DMChannel, GuildMember, SlashCommandBuilder, Message } from 'discord.js'
-import { Cancellable, Command, IntroducePOST, IntroducePUT, RoleDefine, UserGETBody } from '@/types'
+import { CommandInteraction, DMChannel, GuildMember, SlashCommandBuilder, Message, ButtonInteraction, TextChannel, ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js'
+import { Cancellable, Command, He4rtClient, IntroducePOST, RoleDefine, UserGETBody } from '@/types'
 import {
   PRESENTATIONS_CHANNEL,
   PRESENTED_ROLE,
@@ -35,7 +35,7 @@ const removePresentingFlag = async (member: GuildMember) => {
   await member.roles.remove(PRESENTING_ROLE.id)
 }
 
-const nextTextMessage = async (dm: DMChannel, interaction: CommandInteraction): Promise<Cancellable<string>> => {
+const nextTextMessage = async (dm: DMChannel, interaction: CommandInteraction | ButtonInteraction): Promise<Cancellable<string>> => {
   try {
     const result = await dm.awaitMessages({
       filter: (m) => m.author.id === interaction.user.id,
@@ -54,7 +54,7 @@ const nextMultipleRoleSelection = async (
   text: string,
   dm: DMChannel,
   member: GuildMember,
-  interaction: CommandInteraction
+  interaction: CommandInteraction | ButtonInteraction
 ): Promise<number | boolean> => {
   await dm.send(text)
   await dm.send(
@@ -77,7 +77,7 @@ const nextMultipleRoleSelection = async (
   }
 }
 
-const nextUFSelection = async (dm: DMChannel, interaction: CommandInteraction): Promise<string | false> => {
+const nextUFSelection = async (dm: DMChannel, interaction: CommandInteraction | ButtonInteraction): Promise<string | false> => {
   await dm.send(
     VALID_PRESENTATION_RF.reduce(
       (acc, val, index) => (acc += `**${index + 1}**` + ` -   ${val.id} ${val.name}` + '\n'),
@@ -101,7 +101,7 @@ const nextRoleSelection = async (
   text: string,
   dm: DMChannel,
   member: GuildMember,
-  interaction: CommandInteraction
+  interaction: CommandInteraction | ButtonInteraction
 ): Promise<number | false> => {
   await dm.send(text)
   await dm.send(roles.reduce((acc, val, index) => (acc += index + 1 + ` -   ${val.emoji} ${val.name}` + '\n'), '\n'))
@@ -124,7 +124,7 @@ const nextRoleSelection = async (
 const nextHe4rtDelasRole = async (
   dm: DMChannel,
   member: GuildMember,
-  interaction: CommandInteraction
+  interaction: CommandInteraction | ButtonInteraction
 ): Promise<number | false> => {
   const roles: RoleDefine[] = [HE4RT_DELAS_ROLE]
 
@@ -145,7 +145,7 @@ const nextHe4rtDelasRole = async (
   return value
 }
 
-const validateAccess = async (dm: DMChannel, interaction: CommandInteraction): Promise<boolean> => {
+const validateAccess = async (dm: DMChannel, interaction: CommandInteraction | ButtonInteraction): Promise<boolean> => {
   await sendInDM(dm, interaction, INTRODUCTION.CONTINUE)
 
   if (!sendInDM) return false
@@ -155,7 +155,7 @@ const validateAccess = async (dm: DMChannel, interaction: CommandInteraction): P
   return true
 }
 
-const nextStringsData = async (dm: DMChannel, interaction: CommandInteraction): Promise<UserGETBody | false> => {
+const nextStringsData = async (dm: DMChannel, interaction: CommandInteraction | ButtonInteraction): Promise<UserGETBody | false> => {
   await dm.send(INTRODUCTION.USER.NAME)
   const name = await nextTextMessage(dm, interaction)
   if (isCancellable(name)) return false
@@ -197,6 +197,205 @@ const nextStringsData = async (dm: DMChannel, interaction: CommandInteraction): 
   }
 }
 
+const ensureStickyIntroductionMessage = async (client: He4rtClient) => {
+  const channel = getChannel<TextChannel>({ id: PRESENTATIONS_CHANNEL.id, client })
+
+  const messages = await channel.messages.fetchPinned()
+
+  for (const [_, message] of messages) {
+    await message.delete().catch(() => {})
+  }
+
+  const component = new ActionRowBuilder<ButtonBuilder>()
+    .addComponents(
+      new ButtonBuilder()
+        .setCustomId('c-introduce')
+        .setLabel(INTRODUCTION.STICKY.CALL_TO_ACTION)
+        .setStyle(ButtonStyle.Primary)
+    )
+
+  const embed = embedTemplate({
+    title: INTRODUCTION.STICKY.TITLE,
+    description: INTRODUCTION.STICKY.DESCRIPTION,
+    target: {
+      user: client.user,
+      icon: true,
+    }
+  })
+
+  try {
+    const msg = await channel.send({
+      embeds: [embed],
+      components: [component],
+    })
+
+    await msg.pin()
+
+  } catch (e) {
+  }
+}
+
+const startIntroductionFlow = async (client: He4rtClient, interaction: CommandInteraction | ButtonInteraction): Promise<void> => {
+  const author = interaction.user
+  const member = interaction.member as GuildMember
+
+  try {
+    if (isPresentingMember(member)) {
+      await reply(interaction).errorPresentingFail()
+
+      return
+    }
+
+    const dm = await client.users.createDM(author);
+
+    const valid = await validateAccess(dm, interaction)
+
+    if (!valid) return
+
+    await setPresentingFlag(member)
+
+    const body = await nextStringsData(dm, interaction)
+
+    if (body === false) {
+      await dm.send(INTRODUCTION.STOP)
+      return
+    }
+
+    const multipleRoles = await nextMultipleRoleSelection(
+      VALID_PRESENTATION_DEV_ROLES,
+      INTRODUCTION.USER.LANGUAGES,
+      dm,
+      member,
+      interaction
+    )
+
+    if (multipleRoles === false) {
+      await dm.send(INTRODUCTION.STOP)
+      return
+    }
+
+    const role = await nextRoleSelection(
+      VALID_PRESENTATION_ENG_ROLES,
+      INTRODUCTION.USER.ENGLISH,
+      dm,
+      member,
+      interaction
+    )
+
+    if (role === false) {
+      await dm.send(INTRODUCTION.STOP)
+      return
+    }
+
+    const delas = await nextHe4rtDelasRole(dm, member, interaction)
+
+    if (delas === false) {
+      await dm.send(INTRODUCTION.STOP)
+      return
+    }
+
+    const embed = embedTemplate({
+      title: `${INTRODUCTION.EMBED.TITLE}${author.username}`,
+      target: {
+        user: author,
+        icon: true,
+      },
+      delas: delas === 1,
+      fields: [
+        [
+          { name: INTRODUCTION.EMBED.NAME, value: body.info.name, inline: true },
+          { name: INTRODUCTION.EMBED.NICKNAME, value: body.info.nickname, inline: true },
+          { name: INTRODUCTION.EMBED.ABOUT, value: body.info.about, inline: true },
+        ],
+        [
+          { name: INTRODUCTION.EMBED.GIT, value: body.info.github_url, inline: true },
+          { name: INTRODUCTION.EMBED.LINKEDIN, value: body.info.linkedin_url, inline: true },
+          {
+            name: INTRODUCTION.EMBED.LANGUAGES,
+            value: validDisplayDevRoles(member),
+          },
+          {
+            name: INTRODUCTION.EMBED.ENGLISH,
+            value: validDisplayEngRoles(member),
+            inline: true,
+          },
+        ],
+      ],
+    })
+
+    const channel = getChannel({ id: PRESENTATIONS_CHANNEL.id, client })
+
+    await channel
+      .send({
+        content: `👋 <@${interaction.user.id}>!`,
+        embeds: [embed],
+      })
+      .then(async (msg: Message) => {
+        await msg.react(delas === 1 ? HE4RT_DELAS_EMOJI_ID : HE4RT_EMOJI_ID).catch(async () => {
+          await msg.react('💜').catch(() => {})
+        })
+      })
+
+    await member.roles.add(PRESENTED_ROLE.id)
+    await removePresentingFlag(member)
+
+    await ensureStickyIntroductionMessage(client)
+
+    client.api.he4rt.providers.discord
+      .post<IntroducePOST>({
+        provider_id: member.id,
+        username: `${member?.nickname ?? member.user.username}-${member.user.discriminator}`,
+      })
+      .then(() => {
+        client.api.he4rt.users
+          .profile(member.id)
+          .put<IntroducePOST>(body)
+          .then(() => {
+            client.logger.emit({
+              type: 'http',
+              color: 'info',
+              message: `${getTargetMember(member)} apresentou e teve a sua conta criada!`,
+              user: member.user,
+            })
+          })
+          .catch((e) => {
+            client.logger.emit({
+              type: 'http',
+              color: 'error',
+              message: `${getTargetMember(member)} não consegiu criar sua conta! Erro: ${e}`,
+              user: member.user,
+            })
+          })
+      })
+      .catch(() => {
+        client.api.he4rt.users
+          .profile(member.id)
+          .put<IntroducePOST>(body)
+          .then(() => {
+            client.logger.emit({
+              type: 'http',
+              color: 'info',
+              message: `${getTargetMember(member)} apresentou e teve a sua conta alterada!`,
+              user: member.user,
+            })
+          })
+          .catch((e) => {
+            client.logger.emit({
+              type: 'http',
+              color: 'error',
+              message: `${getTargetMember(member)} não consegiu criar sua conta! Erro: ${e}`,
+              user: member.user,
+            })
+          })
+      })
+
+    await dm.send(INTRODUCTION.FINISH)
+  } catch {
+  } finally {
+    await removePresentingFlag(member)
+  }
+}
+
 export const useIntroduction = (): Command => {
   const data = new SlashCommandBuilder()
     .setName(INTRODUCE.TITLE)
@@ -205,152 +404,12 @@ export const useIntroduction = (): Command => {
 
   return [
     data,
-    async (interaction, client) => {
-      const author = interaction.user
-      const member = interaction.member as GuildMember
-
-      if (isPresentingMember(member)) {
-        await reply(interaction).errorPresentingFail()
-
-        return
-      }
-
-      client.users
-        .createDM(author)
-        .then(async (dm) => {
-          const valid = await validateAccess(dm, interaction)
-
-          if (!valid) return
-
-          await setPresentingFlag(member)
-
-          const body = await nextStringsData(dm, interaction)
-
-          if (body === false) return await dm.send(INTRODUCTION.STOP)
-
-          const multipleRoles = await nextMultipleRoleSelection(
-            VALID_PRESENTATION_DEV_ROLES,
-            INTRODUCTION.USER.LANGUAGES,
-            dm,
-            member,
-            interaction
-          )
-
-          if (multipleRoles === false) return await dm.send(INTRODUCTION.STOP)
-
-          const role = await nextRoleSelection(
-            VALID_PRESENTATION_ENG_ROLES,
-            INTRODUCTION.USER.ENGLISH,
-            dm,
-            member,
-            interaction
-          )
-
-          if (role === false) return await dm.send(INTRODUCTION.STOP)
-
-          const delas = await nextHe4rtDelasRole(dm, member, interaction)
-
-          if (delas === false) return await dm.send(INTRODUCTION.STOP)
-
-          const embed = embedTemplate({
-            title: `${INTRODUCTION.EMBED.TITLE}${author.username}`,
-            target: {
-              user: author,
-              icon: true,
-            },
-            delas: delas === 1,
-            fields: [
-              [
-                { name: INTRODUCTION.EMBED.NAME, value: body.info.name, inline: true },
-                { name: INTRODUCTION.EMBED.NICKNAME, value: body.info.nickname, inline: true },
-                { name: INTRODUCTION.EMBED.ABOUT, value: body.info.about, inline: true },
-              ],
-              [
-                { name: INTRODUCTION.EMBED.GIT, value: body.info.github_url, inline: true },
-                { name: INTRODUCTION.EMBED.LINKEDIN, value: body.info.linkedin_url, inline: true },
-                {
-                  name: INTRODUCTION.EMBED.LANGUAGES,
-                  value: validDisplayDevRoles(member),
-                },
-                {
-                  name: INTRODUCTION.EMBED.ENGLISH,
-                  value: validDisplayEngRoles(member),
-                  inline: true,
-                },
-              ],
-            ],
-          })
-
-          const channel = getChannel({ id: PRESENTATIONS_CHANNEL.id, client })
-
-          await channel
-            .send({
-              content: `👋 <@${interaction.user.id}>!`,
-              embeds: [embed],
-            })
-            .then(async (msg: Message) => {
-              await msg.react(delas === 1 ? HE4RT_DELAS_EMOJI_ID : HE4RT_EMOJI_ID).catch(async () => {
-                await msg.react('💜').catch(() => {})
-              })
-            })
-
-          await member.roles.add(PRESENTED_ROLE.id)
-          await removePresentingFlag(member)
-
-          client.api.he4rt.providers.discord
-            .post<IntroducePOST>({
-              provider_id: member.id,
-              username: `${member?.nickname ?? member.user.username}-${member.user.discriminator}`,
-            })
-            .then(() => {
-              client.api.he4rt.users
-                .profile(member.id)
-                .put<IntroducePOST>(body)
-                .then(() => {
-                  client.logger.emit({
-                    type: 'http',
-                    color: 'info',
-                    message: `${getTargetMember(member)} apresentou e teve a sua conta criada!`,
-                    user: member.user,
-                  })
-                })
-                .catch((e) => {
-                  client.logger.emit({
-                    type: 'http',
-                    color: 'error',
-                    message: `${getTargetMember(member)} não consegiu criar sua conta! Erro: ${e}`,
-                    user: member.user,
-                  })
-                })
-            })
-            .catch(() => {
-              client.api.he4rt.users
-                .profile(member.id)
-                .put<IntroducePOST>(body)
-                .then(() => {
-                  client.logger.emit({
-                    type: 'http',
-                    color: 'info',
-                    message: `${getTargetMember(member)} apresentou e teve a sua conta alterada!`,
-                    user: member.user,
-                  })
-                })
-                .catch((e) => {
-                  client.logger.emit({
-                    type: 'http',
-                    color: 'error',
-                    message: `${getTargetMember(member)} não consegiu criar sua conta! Erro: ${e}`,
-                    user: member.user,
-                  })
-                })
-            })
-
-          await dm.send(INTRODUCTION.FINISH)
-        })
-        .catch(() => {})
-        .finally(async () => {
-          await removePresentingFlag(member)
-        })
-    },
+    async (interaction, client) => startIntroductionFlow(client, interaction),
   ]
+}
+
+export const resolveIntroduceCommandButtonEvents = async (client: He4rtClient, interaction: ButtonInteraction) => {
+  if (interaction.customId === 'c-introduce') {
+    await startIntroductionFlow(client, interaction)
+  }
 }

--- a/src/commands/suggest_introduction.ts
+++ b/src/commands/suggest_introduction.ts
@@ -1,0 +1,73 @@
+import { GuildMember, SlashCommandBuilder, ButtonBuilder, ActionRowBuilder, ButtonStyle } from 'discord.js'
+import { Command } from '@/types'
+import SUGGEST_INTRODUCE_LABELS from '-/commands/suggest_introduction.json'
+import { SUGGEST_INTRODUCE } from '@/defines/commands.json'
+import {
+  interpolate,
+  isPresentedMember,
+  isPresentingMember,
+  reply,
+} from '@/utils'
+import { embedTemplate } from '@/utils'
+
+
+export const useSuggestIntroduction = (): Command => {
+  const data = new SlashCommandBuilder()
+    .setName(SUGGEST_INTRODUCE.TITLE)
+    .setDescription(SUGGEST_INTRODUCE.DESCRIPTION)
+    .setDMPermission(false)
+    .addUserOption(
+      option =>
+        option
+          .setRequired(true)
+          .setName('member')
+          .setDescription(SUGGEST_INTRODUCE_LABELS.OPTIONS_MEMBER)
+    )
+
+  return [
+    data,
+    async (interaction, client) => {
+      const author = interaction.user
+      const target = interaction.options.getMember('member') as GuildMember
+
+      if (isPresentingMember(target)) {
+        await reply(interaction).errorMemberPresentingFail()
+        return
+      }
+      
+      if (isPresentedMember(target)) {
+        await reply(interaction).errorMemberPresentedFail()
+        return
+      }
+
+      const component = new ActionRowBuilder<ButtonBuilder>()
+        .addComponents(
+          new ButtonBuilder()
+            .setCustomId('c-introduce')
+            .setLabel(SUGGEST_INTRODUCE_LABELS.CALL_TO_ACTION)
+            .setStyle(ButtonStyle.Primary)
+        )
+
+      const embed = embedTemplate({
+        title: interpolate(
+          SUGGEST_INTRODUCE_LABELS.EMBED.TITLE,
+          { user: target.user.username }
+        ),
+        author: author,
+        target: {
+          user: target.user,
+          icon: true,
+        },
+        description: SUGGEST_INTRODUCE_LABELS.EMBED.DESCRIPTION,
+      })
+      
+      await interaction.channel.send({
+        content: `<@${target.user.id}>`,
+        embeds: [embed],
+        components: [component]
+      })
+
+      await reply(interaction).success()
+    },
+  ]
+}

--- a/src/defines/commands.json
+++ b/src/defines/commands.json
@@ -3,6 +3,10 @@
     "TITLE": "apresentar",
     "DESCRIPTION": "Se apresente para os membros de nossa comunidade e ganhe cargos!"
   },
+  "SUGGEST_INTRODUCE": {
+    "TITLE": "pedir-apresentar",
+    "DESCRIPTION": "Sugira alguém à se apresentar com um botão de fácil acesso."
+  },
   "ANNOUNCE": {
     "TITLE": "anunciar",
     "DESCRIPTION": "ADM: Anuncie no canal de anúncios com o uso do everyone automático."

--- a/src/defines/localisation/commands/introduction.json
+++ b/src/defines/localisation/commands/introduction.json
@@ -24,5 +24,10 @@
     "LANGUAGES": "**Linguagens:**",
     "ENGLISH": "**Nível de Inglês:**"
   },
-  "FINISH": "**Sua apresentação foi concluída com sucesso!**"
+  "FINISH": "**Sua apresentação foi concluída com sucesso!**",
+  "STICKY": {
+    "TITLE": "Ainda não se apresentou?",
+    "DESCRIPTION": "Clique no botão abaixo e se apresente! **O nosso bot te mandará uma DM.**\n\nAo se apresentar, você ganha acesso aos diversos canais da He4rt.",
+    "CALL_TO_ACTION": "Apresentar"
+  }
 }

--- a/src/defines/localisation/commands/suggest_introduction.json
+++ b/src/defines/localisation/commands/suggest_introduction.json
@@ -1,0 +1,8 @@
+{
+  "OPTIONS_MEMBER": "Pessoa para se apresentar",
+  "CALL_TO_ACTION": "Apresentar",
+  "EMBED": {
+    "TITLE": "Fale um pouco de você para a comunidade, ${user}!",
+    "DESCRIPTION": "Clique no botão abaixo para se apresentar, o nosso bot te enviará uma DM! Ao se apresentar, você ganha acesso aos diversos canais da He4rt."
+  }
+}

--- a/src/defines/localisation/defaults/reply.json
+++ b/src/defines/localisation/defaults/reply.json
@@ -11,5 +11,7 @@
   "ERROR_CHANNEL_PERMISSION": "Só é permitido usar este comando no canal ",
   "ERROR_CANNOT_BE_BANNED": "O usuário em questão não pode ser banido ou desbanido!",
   "ERROR_PAGINATION": "Este número de página não existe.",
-  "ERROR_PRESENTING": "**Você já está se apresentando! Consulte sua DM.**"
+  "ERROR_PRESENTING": "**Você já está se apresentando! Consulte sua DM.**",
+  "ERROR_MEMBER_PRESENTING": "**Usuário já está se apresentando!**",
+  "ERROR_MEMBER_PRESENTED": "**Usuário já se apresentou!**"
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,6 +51,8 @@ import {
   ERROR_CANNOT_BE_BANNED,
   ERROR_PAGINATION,
   ERROR_PRESENTING,
+  ERROR_MEMBER_PRESENTING,
+  ERROR_MEMBER_PRESENTED
 } from '-/defaults/reply.json'
 import { NOT_FOUND, LANGUAGE_NONE } from '-/defaults/display.json'
 import { TIMEOUT_COMMAND_STRING, DEFINE_STRING_REPLACED } from '@/defines/values.json'
@@ -255,6 +257,10 @@ export const replaceDefineString = (str: string, target: string) => {
   return str.replaceAll(DEFINE_STRING_REPLACED, target)
 }
 
+export const interpolate = (str: string, replacements: object) => {
+  return str.replace(/\$\{.+?\}/g, (match) => match.slice(2, -1).split('.').reduce((res, key) => res[key] || match, replacements))
+}
+
 export const sendInDM = async (dm: DMChannel, interaction: CommandInteraction | ButtonInteraction, str: string) => {
   await dm.send(str).catch(async () => {
     await reply(interaction).errorInAccessDM()
@@ -364,6 +370,14 @@ export const reply = (interaction: CommandInteraction | ButtonInteraction) => {
     await interaction.reply({ content: ERROR_PRESENTING, ephemeral: true })
   }
 
+  const errorMemberPresentingFail = async () => {
+    await interaction.reply({ content: ERROR_MEMBER_PRESENTING, ephemeral: true })
+  }
+
+  const errorMemberPresentedFail = async () => {
+    await interaction.reply({ content: ERROR_MEMBER_PRESENTED, ephemeral: true })
+  }
+
   return {
     success,
     successInAccessDM,
@@ -378,6 +392,8 @@ export const reply = (interaction: CommandInteraction | ButtonInteraction) => {
     errorSpecificChannel,
     errorPaginationFail,
     errorPresentingFail,
+    errorMemberPresentingFail,
+    errorMemberPresentedFail,
   }
 }
 


### PR DESCRIPTION
This PR adds two functionalities:
1. adds a new command `/pedir-apresentar @member` to send a message with an "Apresentar" button, to help people getting into the introduction flow. It could also be `/apresentar @member` but it may be confusing.
2. adds a sticky message to the introductions channel, with the same "Apresentar" button.

![image](https://github.com/he4rt/he4rt-bot-next/assets/562525/994bb14c-fbc4-4c14-8af1-fd29e9001077)
