### PR TITLE
fix: remove message 'heartdevs.com pinned a message'

### DIFF
--- a/src/events/discord/channel.ts
+++ b/src/events/discord/channel.ts
@@ -6,6 +6,7 @@ import {
   MEETING_DELAS_CHANNEL,
   LEARNING_DIARY_CHANNEL,
   ADVERTS_CHANNEL,
+  PRESENTATIONS_CHANNEL,
 } from '@/defines/ids.json'
 import { HE4RT_EMOJI_ID } from '@/defines/ids.json'
 import { isAdministrator, isImageHTTPUrl, isValidProxyContent, js } from '@/utils'
@@ -96,6 +97,12 @@ export const bussinOrCap = async (message: Message) => {
     } else if (containsGo && randomness === 69) {
       message.reply({ content: 'cap' }).catch(() => {})
     }
+  }
+}
+
+export const deletePinningMessagesInPresentationChannel = async (message: Message) => {
+  if (PRESENTATIONS_CHANNEL.id === message.channel.id && message.type === MessageType.ChannelPinnedMessage) {
+    await message.delete().catch(() => {})
   }
 }
 

--- a/src/events/discord/index.ts
+++ b/src/events/discord/index.ts
@@ -12,6 +12,7 @@ import {
   bussinOrCap,
   MessageListener,
   reactMessagesInDepositionsChannel,
+  deletePinningMessagesInPresentationChannel,
 } from './channel'
 import { setMemberIsAPrivilegedOrNot, setMemberIsANitroOrNot, userBoostingServerMessage } from './role'
 import { removeUserMuteInLeavePomodoro } from './voice'
@@ -45,6 +46,7 @@ export const discordEvents = async (client: He4rtClient) => {
 
   client.on(Events.MessageCreate, (message) => {
     reactAnnouncesInAdvertsChannel(message)
+    deletePinningMessagesInPresentationChannel(message)
 
     if (isBot(message.author)) return
 


### PR DESCRIPTION
The pinning messages in the introduction channel are pestering, while does not give any useful information- the pinned message is just for internal purpose, helping create the sticky message.

This PR adds code to remove the `heartdevs.com pinned a message` message once it appears to the message listener.
![image](https://github.com/he4rt/he4rt-bot-next/assets/562525/190a525a-61ce-4763-9112-95556c69da95)