### PR TITLE
fix: forces know_hosts to be updated

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 name: Deploy
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,8 @@ jobs:
           REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
           REMOTE_USER: ${{ secrets.REMOTE_USER }}
           TARGET: ${{ secrets.REMOTE_TARGET }}
+          SCRIPT_BEFORE: |
+            echo "Connected from GitHub Actions!"
 
       - name: Restart service
         uses: appleboy/ssh-action@master


### PR DESCRIPTION
This pull request includes updates to the deployment workflow configuration to enhance flexibility and provide additional logging.

Enhancements to deployment workflow:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R4): Added `workflow_dispatch` event to allow manual triggering of the deployment workflow.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R29-R30): Added a `SCRIPT_BEFORE` step to log a connection message from GitHub Actions before restarting the service, and force the know_hosts to be updated based on the action [documentation](https://github.com/easingthemes/ssh-deploy/blob/a1aa0b6cf96ce2406eef90faa35007a4a7bf0ac0/README.md#L63-L68)