### PR TITLE
refactor: replace direct firebase init

### DIFF
--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -1,7 +1,8 @@
 import { createClient } from 'uncreate'
 import { destr as JSON_PARSE } from 'destr'
-import firebase_admin from '../../firebase_admin.json'
 import firebase from 'firebase-admin'
+import path from 'path'
+import fs from 'fs/promises'
 
 export const HE4RT = createClient({
   parseResponse: JSON_PARSE,
@@ -23,10 +24,15 @@ export const APOIASE = createClient({
   },
 })
 
-const FIREBASE = firebase.initializeApp({
-  // @ts-expect-error
-  credential: firebase.credential.cert(firebase_admin),
-  databaseURL: process.env.FIREBASE_DATABASE_URL,
-})
+export const createFirebaseClient = async (): Promise<firebase.firestore.Firestore> => {
+  const FILE_PATH = path.resolve(__dirname, '..', '..', 'firebase_admin.json')
+  const RAW_FILE = await fs.readFile(FILE_PATH, 'utf-8')
+  const firebaseConfig = JSON.parse(RAW_FILE)
 
-export const FIRESTORE = FIREBASE.firestore()
+  return firebase
+    .initializeApp({
+      databaseURL: process.env.FIREBASE_DATABASE_URL,
+      credential: firebase.credential.cert(firebaseConfig),
+    })
+    .firestore()
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { Client, Collection, GatewayIntentBits, Options, REST } from 'discord.js'
 import { Context, He4rtClient } from './types'
 import { registerCommands } from './commands'
-import { HE4RT, APOIASE, FIRESTORE } from './http'
+import { HE4RT, APOIASE, createFirebaseClient } from './http'
 import { Ticker } from './client/ticker'
 import { Logger } from './client/logger'
 
@@ -22,7 +22,11 @@ export const runner = async (): Promise<Context> => {
   client.commands = new Collection()
   client.ticker = new Ticker()
   client.logger = new Logger(client)
-  if (process.env.FIREBASE_DATABASE_URL) client.firestore = FIRESTORE
+
+  if (process.env.FIREBASE_DATABASE_URL) {
+    client.firestore = await createFirebaseClient()
+  }
+
   client.api = {
     he4rt: HE4RT,
     apoiase: APOIASE,


### PR DESCRIPTION
## Summary

This pull request refactors the Firebase client initialization to improve flexibility and error handling, since we don't need it to run the entire application on local development.

### Firebase client initialization refactor:

* `src/http/index.ts`: Removed the static import of `firebase_admin.json` and replaced it with a dynamic file read using `fs/promises` and `path`. Introduced a new `createFirebaseClient` asynchronous function to initialize the Firebase client dynamically, making it more flexible and suitable for runtime environments.

### Updates to main application:

* `src/main.ts`: Updated the `runner` function to use the new `createFirebaseClient` function for initializing the Firestore client. This ensures the Firebase client is only initialized if the required environment variable (`FIREBASE_DATABASE_URL`) is present.

---

> Another option is to also provide `firebase_admin` via environment variables, but this will break the current setup of deploy