### PR TITLE
refactor: change ticker events to be async functions

### DIFF
--- a/src/events/ticker/dynamic_voice.ts
+++ b/src/events/ticker/dynamic_voice.ts
@@ -3,12 +3,12 @@ import {
   DYNAMIC_VOICE_DELETE_CHANNELS_IN_MINUTES,
   DYNAMIC_VOICE_INVITE_LIMIT_TIME,
   DYNAMIC_VOICE_IGNORABLE_CHANNELS,
-  TICKER_SETTER
+  TICKER_SETTER,
 } from '@/defines/values.json'
 import { getDynamicVoiceCategory, getGuild } from '@/utils'
 import { Collection, GuildMember, VoiceChannel } from 'discord.js'
 
-export const setDynamicVoice = (client: He4rtClient) => {
+export const setDynamicVoice = async (client: He4rtClient) => {
   const guild = getGuild(client)
 
   const voiceTimer = 60 * DYNAMIC_VOICE_DELETE_CHANNELS_IN_MINUTES
@@ -26,14 +26,14 @@ export const setDynamicVoice = (client: He4rtClient) => {
       channels.forEach(async ([_, channel]) => {
         if (channel.parentId !== category.id) return
 
-        if (!DYNAMIC_VOICE_IGNORABLE_CHANNELS.some(i => i === channel.name)) {
+        if (!DYNAMIC_VOICE_IGNORABLE_CHANNELS.some((i) => i === channel.name)) {
           const targets = [...(channel.members as Collection<string, GuildMember>)]
-  
+
           const actuallyTime = new Date().valueOf()
           const expirationLimitTime = new Date(channel.createdAt).valueOf() + DYNAMIC_VOICE_INVITE_LIMIT_TIME
-  
+
           const debounceTime = actuallyTime > expirationLimitTime
-  
+
           if (targets.length === 0 && debounceTime) {
             channel
               .delete()

--- a/src/events/ticker/presence.ts
+++ b/src/events/ticker/presence.ts
@@ -2,7 +2,7 @@ import { He4rtClient, TickerName } from '@/types'
 import { ActivityType } from 'discord.js'
 import { DISCORD_PRESENCE_IN_MINUTES, TICKER_SETTER } from '@/defines/values.json'
 
-export const setPresence = (client: He4rtClient) => {
+export const setPresence = async (client: He4rtClient) => {
   const type = ActivityType.Watching as Exclude<ActivityType, ActivityType.Custom>
 
   const activities = [


### PR DESCRIPTION
## Summary

This pull request ensures the correct execution of `tickerEvents`, as pointed out by some users, the bot doesn't delete the dynamic voice channel and the bot's `rich presence` is not set up.

<details> <summary>See more</summary>
<div>Current operation</div>
<img src="https://github.com/user-attachments/assets/8164e217-166d-45b0-aa2a-038e47f25df8" alt="Discord Rich Presence">
<div>Correct operation</div>
<img src="https://github.com/user-attachments/assets/77eb120c-2d5b-45c3-b008-cb8c7776b3f4" alt="Correct Rich Presence">
</details>

### Changes to asynchronous behavior:

* `dynamic_voice.ts`: Updated `setDynamicVoice` to be an `async` function to support asynchronous operations within its logic.
* `presence.ts`: Updated `setPresence` to be an `async` function to ensure it can handle asynchronous operations effectively.