### PR TITLE
refactor: remove pomodoro setup

### DIFF
--- a/src/events/discord/index.ts
+++ b/src/events/discord/index.ts
@@ -14,7 +14,6 @@ import {
   reactMessagesInDepositionsChannel,
 } from './channel'
 import { setMemberIsAPrivilegedOrNot, setMemberIsANitroOrNot, userBoostingServerMessage } from './role'
-import { removeUserMuteInLeavePomodoro } from './voice'
 import { emitDefaultDiscordError, emitWebhookUpdate } from './logger'
 
 export const discordEvents = async (client: He4rtClient) => {
@@ -37,10 +36,6 @@ export const discordEvents = async (client: He4rtClient) => {
     await setMemberIsAPrivilegedOrNot(client, oldMember as GuildMember, newMember)
     await setMemberIsANitroOrNot(client, oldMember as GuildMember, newMember)
     await userBoostingServerMessage(client, oldMember as GuildMember, newMember)
-  })
-
-  client.on(Events.VoiceStateUpdate, (oldVoice, newVoice) => {
-    removeUserMuteInLeavePomodoro(oldVoice, newVoice)
   })
 
   client.on(Events.MessageCreate, (message) => {

--- a/src/events/ticker/index.ts
+++ b/src/events/ticker/index.ts
@@ -1,12 +1,10 @@
 import { He4rtClient } from '@/types'
 import { setDynamicVoice } from './dynamic_voice'
-import { setPomodoro } from './pomodoro'
 import { setPresence } from './presence'
 import { setVoiceXP } from './voice_xp'
 import { setMedalsExpires } from './medals'
 
 export const tickerEvents = async (client: He4rtClient) => {
-  await setPomodoro(client)
   await setPresence(client)
   await setVoiceXP(client)
   await setDynamicVoice(client)


### PR DESCRIPTION
## Summary

This pull request removes unused functionality related to pomodoro timers and voice state updates. Also, as @1pride pointed out, the `Pomodoro` channel has been removed in the past, so at this point we're just removing the initialization of it.

### Removal of Pomodoro-related functionality:
* `src/events/discord/index.ts`: Removed the `removeUserMuteInLeavePomodoro` import and the associated `VoiceStateUpdate` event handler.
* `src/events/ticker/index.ts`: Removed the `setPomodoro` import and its invocation in the `tickerEvents` function.