### PR TITLE
fix: color command usage

### DIFF
--- a/src/commands/color.ts
+++ b/src/commands/color.ts
@@ -17,7 +17,8 @@ export const useColor = (): Command => {
     data,
     async (interaction, client) => {
       const member = interaction.member as GuildMember
-      const nick = interaction.user.username
+      const nick = interaction.user.tag
+
       const hex = interaction.options.get('hex') as CommandInteractionOption
       const color = hex.value as HexColorString
 

--- a/src/commands/color.ts
+++ b/src/commands/color.ts
@@ -56,7 +56,7 @@ export const useColor = (): Command => {
       if (!colorRole) {
         interaction?.guild?.roles
           .create({
-            name: `${nick}#0001`,
+            name: nick,
             color,
             permissions: [],
             hoist: false,
@@ -84,7 +84,7 @@ export const useColor = (): Command => {
       }
 
       await colorRole.setColor(color).catch(() => {})
-      if (!isCustomColorRole(highestRole.name)) await colorRole.setPosition(priority).catch(() => {})
+      if (!isCustomColorRole(highestRole.name, colorRole.name)) await colorRole.setPosition(priority).catch(() => {})
 
       client.logger.emit({
         message: `${getTargetMember(member)} atualizou seu cargo colorido!`,

--- a/src/commands/color.ts
+++ b/src/commands/color.ts
@@ -17,8 +17,7 @@ export const useColor = (): Command => {
     data,
     async (interaction, client) => {
       const member = interaction.member as GuildMember
-      const nick = interaction.user.tag
-
+      const nick = interaction.user.username
       const hex = interaction.options.get('hex') as CommandInteractionOption
       const color = hex.value as HexColorString
 
@@ -56,7 +55,7 @@ export const useColor = (): Command => {
       if (!colorRole) {
         interaction?.guild?.roles
           .create({
-            name: nick,
+            name: `${nick}#0001`,
             color,
             permissions: [],
             hoist: false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -141,8 +141,8 @@ export const isValidId = (id: number, arr: any[]) => {
   return !isNaN(id) && id <= arr.length && id > 0
 }
 
-export const isCustomColorRole = (name: string) => {
-  return /.+#\d{4}/i.test(name)
+export const isCustomColorRole = (rolename: string, username: string) => {
+  return rolename === username
 }
 
 export const isCancellable = (str: string) => {
@@ -232,8 +232,8 @@ export const getOption: CommandGetOption = (interaction: CommandInteraction, tar
   return interaction.options.get(target) as CommandInteractionOption
 }
 
-export const getCustomColorRole = ({ roles }: GuildMember | PartialGuildMember) => {
-  return roles.cache.find((x) => isCustomColorRole(x.name)) || false
+export const getCustomColorRole = ({ roles, user }: GuildMember | PartialGuildMember) => {
+  return roles.cache.find((x) => isCustomColorRole(x.name, user.username)) || false
 }
 
 export const getTaggedMembers = (ids: string[]): string => {


### PR DESCRIPTION
### Summary

This pull request updates the logic for handling custom color roles in a Discord bot by refining the `isCustomColorRole` function and its usage. The changes ensure that the role name is validated against the user's name, improving accuracy in identifying custom color roles.

### Extra links

- [New Usernames & Display Names ](https://support.discord.com/hc/en-us/articles/12620128861463-New-Usernames-Display-Names)
- [Evolving Usernames on Discord](https://discord.com/blog/usernames)